### PR TITLE
refactor: 검색 리팩토링 #KAN-45

### DIFF
--- a/src/main/java/com/coop/domain/post/entity/PostDocument.java
+++ b/src/main/java/com/coop/domain/post/entity/PostDocument.java
@@ -1,5 +1,6 @@
 package com.coop.domain.post.entity;
 
+import com.coop.domain.member.entity.Member;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -17,6 +18,9 @@ import java.time.LocalDateTime;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class PostDocument {
+
+    private static final int PREVIEW_LENGTH = 50;
+
     @Id
     private Long id;
 
@@ -50,5 +54,22 @@ public class PostDocument {
         this.author = author;
         this.category = category;
         this.updatedAt = updatedAt;
+    }
+
+    public static PostDocument of(Post post, Member member) {
+        return PostDocument.builder()
+                .id(post.getId())
+                .title(post.getTitle())
+                .contentPreview(generatePreview(post.getContent()))
+                .author(member.getNickname())
+                .category(post.getCategory().toString())
+                .updatedAt(post.getUpdatedAt())
+                .build();
+    }
+
+    private static String generatePreview(String content) {
+        return content.length() > PREVIEW_LENGTH
+                ? content.substring(0, PREVIEW_LENGTH) + "..."
+                : content;
     }
 }

--- a/src/main/java/com/coop/domain/post/event/PostCreatedEventListener.java
+++ b/src/main/java/com/coop/domain/post/event/PostCreatedEventListener.java
@@ -1,6 +1,6 @@
 package com.coop.domain.post.event;
 
-import com.coop.domain.post.service.PostEsService;
+import com.coop.global.util.ElasticsearchBatchProcessor;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.event.EventListener;
@@ -12,15 +12,15 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class PostCreatedEventListener {
 
-    private final PostEsService postEsService;
+    private final ElasticsearchBatchProcessor elasticsearchBatchProcessor;
 
     @Async
     @EventListener
     public void handlePostCreateEvent(PostCreatedEvent event) {
         try {
-            postEsService.generatePostDocument(event.getPost(), event.getMember());
+            elasticsearchBatchProcessor.addToQueue(event);
         } catch (Exception e) {
-            log.error("엘라스틱서치 문서 생성 실패", e);
+            log.error("엘라스틱서치 문서 큐 추가 실패", e);
         }
     }
 }

--- a/src/main/java/com/coop/domain/post/service/PostEsService.java
+++ b/src/main/java/com/coop/domain/post/service/PostEsService.java
@@ -3,10 +3,13 @@ package com.coop.domain.post.service;
 import com.coop.domain.member.entity.Member;
 import com.coop.domain.post.entity.Post;
 import com.coop.domain.post.entity.PostDocument;
+import com.coop.domain.post.event.PostCreatedEvent;
 import com.coop.domain.post.repository.PostEsRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -17,22 +20,16 @@ public class PostEsService {
 
     @Transactional
     public void generatePostDocument(Post post, Member member) {
-        PostDocument document = PostDocument.builder()
-                .id(post.getId())
-                .title(post.getTitle())
-                .contentPreview(generatePreview(post.getContent()))
-                .author(member.getNickname())
-                .category(post.getCategory().toString())
-                .updatedAt(post.getUpdatedAt())
-                .build();
-
+        PostDocument document = PostDocument.of(post, member);
         postEsRepository.save(document);
     }
 
-    private String generatePreview(String content) {
-        int previewLength = 50;
-        return content.length() > previewLength
-                ? content.substring(0, previewLength) + "..."
-                : content;
+    @Transactional
+    public void saveAllFromEvents(List<PostCreatedEvent> events) {
+        List<PostDocument> documents = events.stream()
+                .map(event -> PostDocument.of(event.getPost(), event.getMember()))
+                .toList();
+
+        postEsRepository.saveAll(documents);
     }
 }

--- a/src/main/java/com/coop/domain/post/service/PostSearchService.java
+++ b/src/main/java/com/coop/domain/post/service/PostSearchService.java
@@ -33,28 +33,28 @@ public class PostSearchService {
     private final ElasticsearchClient elasticsearchClient;
 
     public PostDocPageResponse getPostDocsBySearching(
-            Pageable pageable, String title, String content, String author, String category, String updatedAt
+            Pageable pageable, String keyword, String author, String category, String updatedAt
     ) {
         Page<PostDocument> postDocuments = searchByFields
-                (pageable, title, content, author, category, updatedAt != null ? LocalDateTime.parse(updatedAt) : null);
+                (pageable, keyword, author, category, updatedAt != null ? LocalDateTime.parse(updatedAt) : null);
         Page<PostDocsResponse> postPage = postDocuments.map(PostDocsResponse::of);
 
         return PostDocPageResponse.from(postPage);
     }
 
     private Page<PostDocument> searchByFields(
-            Pageable pageable, String title, String content, String author, String category, LocalDateTime updatedAt
+            Pageable pageable, String keyword, String author, String category, LocalDateTime updatedAt
     ) {
         BoolQuery.Builder boolQueryBuilder = new BoolQuery.Builder();
 
-        if (StringUtils.hasText(title)) {
+        if (StringUtils.hasText(keyword)) {
             boolQueryBuilder.must(
-                    q -> q.match(m -> m.field("title").query(title)));
+                    q -> q.match(m -> m.field("title").query(keyword)));
         }
 
-        if (StringUtils.hasText(content)) {
+        if (StringUtils.hasText(keyword)) {
             boolQueryBuilder.must(
-                    q -> q.match(m -> m.field("contentPreview").query(content)));
+                    q -> q.match(m -> m.field("contentPreview").query(keyword)));
         }
 
         if (StringUtils.hasText(author)) {

--- a/src/main/java/com/coop/global/util/ElasticsearchBatchProcessor.java
+++ b/src/main/java/com/coop/global/util/ElasticsearchBatchProcessor.java
@@ -1,0 +1,83 @@
+package com.coop.global.util;
+
+import com.coop.domain.post.event.PostCreatedEvent;
+import com.coop.domain.post.service.PostEsService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ElasticsearchBatchProcessor {
+
+    private static final int BATCH_SIZE = 1000;
+    private final Queue<PostCreatedEvent> indexingQueue = new ConcurrentLinkedQueue<>();
+    private final Queue<PostCreatedEvent> failedQueue = new ConcurrentLinkedQueue<>();
+    private final PostEsService postEsService;
+
+    public void addToQueue(PostCreatedEvent event) {
+        indexingQueue.add(event);
+
+        if (indexingQueue.size() >= BATCH_SIZE) {
+            processBatch();
+        }
+    }
+
+    @Async
+    protected synchronized void processBatch() {
+        List<PostCreatedEvent> events = new ArrayList<>(BATCH_SIZE);
+        int processedCount = 0;
+
+        while (!indexingQueue.isEmpty() && processedCount < BATCH_SIZE) {
+            PostCreatedEvent event = indexingQueue.poll();
+            if (event != null) {
+                events.add(event);
+                processedCount++;
+            }
+        }
+
+        if (!events.isEmpty()) {
+            try {
+                postEsService.saveAllFromEvents(events);
+                log.info("배치 처리 완료: {}개 포스트 인덱싱", events.size());
+            } catch (Exception e) {
+                log.error("배치 인덱싱 실패:", e);
+                failedQueue.addAll(events);
+            }
+        }
+    }
+
+    @Scheduled(fixedDelay = 1800000) // 30m
+    public void scheduledBatchProcessing() {
+        if (!indexingQueue.isEmpty()) {
+            processBatch();
+        }
+    }
+
+    @Scheduled(fixedDelay = 1800000) // 30m
+    public void retryFailedBatch() {
+        if (!failedQueue.isEmpty()) {
+            List<PostCreatedEvent> retryEvents = new ArrayList<>();
+            while (!failedQueue.isEmpty() && retryEvents.size() < BATCH_SIZE) {
+                PostCreatedEvent event = failedQueue.poll();
+                if (event != null) retryEvents.add(event);
+            }
+
+            try {
+                postEsService.saveAllFromEvents(retryEvents);
+                log.info("실패한 배치 재시도 성공: {}개", retryEvents.size());
+            } catch (Exception e) {
+                log.error("실패한 배치 재시도 실패", e);
+                failedQueue.addAll(retryEvents);
+            }
+        }
+    }
+}

--- a/src/main/java/com/coop/presentation/post/controller/PostController.java
+++ b/src/main/java/com/coop/presentation/post/controller/PostController.java
@@ -37,7 +37,9 @@ public class PostController {
             @RequestParam(required = false) String category
     ) {
         Pageable pageable = PageRequest.of(page - 1, size, Sort.by("createdAt").descending());
-        return ApiResponse.success(postService.getPosts(pageable, category));
+        PostPageResponse responseDto = postService.getPosts(pageable, category);
+
+        return ApiResponse.success(responseDto);
     }
 
     @GetMapping("/{postId}")
@@ -47,8 +49,11 @@ public class PostController {
             @RequestParam(defaultValue = "10") int size
     ) {
         Pageable pageable = PageRequest.of(page - 1, size, Sort.by("createdAt").ascending());
-        return ApiResponse.success(postService.getPost(postId, pageable));
+        PostResponse responseDto = postService.getPost(postId, pageable);
+
+        return ApiResponse.success(responseDto);
     }
+
 
     @PatchMapping("/{postId}")
     public ResponseEntity<ApiResponse<Void>> updatePost(

--- a/src/main/java/com/coop/presentation/post/controller/PostSearchController.java
+++ b/src/main/java/com/coop/presentation/post/controller/PostSearchController.java
@@ -30,15 +30,14 @@ public class PostSearchController {
     public ResponseEntity<ApiResponse<PostDocPageResponse>> readPostsBySearching(
             @RequestParam(defaultValue = "1") int page,
             @RequestParam(defaultValue = "15") int size,
-            @RequestParam(required = false) String title,
-            @RequestParam(required = false) String content,
+            @RequestParam(required = false) String keyword,
             @RequestParam(required = false) String author,
             @RequestParam(required = false) String category,
             @RequestParam(required = false) String updatedAt
     ) {
         Pageable pageable = PageRequest.of(page - 1, size, Sort.by("updatedAt").descending());
         PostDocPageResponse responseDto =
-                postSearchService.getPostDocsBySearching(pageable, title, content, author, category, updatedAt);
+                postSearchService.getPostDocsBySearching(pageable, keyword, author, category, updatedAt);
 
         return ApiResponse.success(responseDto);
     }


### PR DESCRIPTION
## #️⃣ Kan Ban Board Number

[KAN-45](https://studyspring.atlassian.net/browse/KAN-45)

## 📝 요약

-  **1. Elasticsearch 문서 저장 배치 처리 구현으로 성능개선**

     - 포스트 생성 시 포스트 하나 당 Elasticsearch에 Document 하나를 생성 (데이터 100,000건 -> 23분 소요)
     - 발행된 이벤트로 이루어진 Queue에 indexingQueue가 1,000개 쌓일 때마다 배치 처리 (데이터 100,000건 -> 52초 소요)
     
    ![스크린샷 2025-05-02 212217](https://github.com/user-attachments/assets/e3e4dcf1-870a-458a-9987-2917facd5594)
    ![스크린샷 2025-05-02 205458](https://github.com/user-attachments/assets/45b54ff2-ac75-4ce6-aa7a-159a2de8e679)


-  **2. 검색 파라미터 통합**

    - title, content로 분리되어 있던 파라미터를 keyword로 통합하여 사용자성 개선

-   **3. 응답 객체 할당 방식 변경으로 코드 가독성 개선**

## 🛠️ PR 유형

- [ ] 배포용 PR : dev 테스트를 완료하였나요?
- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 💬 논의사항 or 질문


## ✅ PR Checklist

PR이 다음 요구 사항을 충족했는지 확인하기!

- [x] 커밋 메시지 컨벤션 준수
- [x] 변경 사항 테스트 여부 체크(버그 수정/기능 테스트)

## 💥 리뷰어 지목!!!!!

<!--- 리뷰어를 2명 이상 지목해주세요. -->
- [x] 창현
- [ ] 예나
- [x] 승근
- [ ] 채영
